### PR TITLE
Call afterNextFrameAnimatesIn in fallback mode

### DIFF
--- a/scripts/sequence.jquery.js
+++ b/scripts/sequence.jquery.js
@@ -525,6 +525,7 @@ Aside from these comments, you may modify and distribute this file as you please
 						self.currentFrame.removeClass("current");
 						self.settings.beforeNextFrameAnimatesIn();
 						nextFrame.addClass("current").css({"display": "block", "z-index": self.numberOfFrames}).animate({"opacity": 1}, 500); //make the next frame the current one and show it
+						self.settings.afterNextFrameAnimatesIn();
 						self.currentFrame = nextFrame;
 						self.currentFrameID = self.currentFrame.index() + 1;
 						self.active = false;


### PR DESCRIPTION
Adds a call to the afterNextFrameAnimatesIn callback in fallback mode. I'm not sure whether you'd prefer it where I added it, or in the completion callback for .animate({"opacity": 1}, 500), but it should be called.
