### PR TITLE
Callback before init

### DIFF
--- a/scripts/sequence.jquery.js
+++ b/scripts/sequence.jquery.js
@@ -134,6 +134,7 @@ Aside from these comments, you may modify and distribute this file as you please
 				$(window).unbind("load");
 			});
 		}else{
+			self.settings.afterPreload();
 			init();
 		}
 		


### PR DESCRIPTION
I have an instance of Sequence, that uses a navigation quite similar to the one you used in the _Modern Slide In_-Demo. The initialisation of this navigation uses the same code the demo uses:

``` javascript
afterPreload: function(){
    $("#nav").fadeIn(100);
    $("#nav li:nth-child("+(sequence.settings.startingFrameID)+") img").addClass("active");
}, 

```

My problem is that - at the moment - I don't use the preloader and as a result, that function isn't called at all. Right now I implemented a solution, that calls it even if `preloader === false`. 
Maybe it would be better to have another callback like `afterInit`, that can be used for further initialisation and is called independent from the preloader. What do you think?
