### PR TITLE
fix bug with nextFrameID

### DIFF
--- a/scripts/jquery.sequence.js
+++ b/scripts/jquery.sequence.js
@@ -286,6 +286,7 @@ Sequence also relies on the following open source scripts:
 
 				self.paginationLinks.on('click.sequence', function() { //when a pagination link is clicked...
 					var associatedFrameNumber = $(this).index() + 1; //get the number of the frame this link is associated with
+					self.nextFrameID = associatedFrameNumber;
 					self.goTo(associatedFrameNumber); //go to the associate frame
 				});
 


### PR DESCRIPTION
Hello,

I had a problem with Sequence using the callback beforeNextFrameAnimatesIn. The problem occurs when using the pagination links : the nextFrameID variable don't have the good value (it has the value of currentFrameID). However, when using  next and prev buttons, nextFrameID has the right value. 

So i looked at the code and noticed self.nextFrameID is set in the next/prev buttons click handlers before the callback is called. But it isn't in the pagination handler. So i added it and it seems to work now

This is a one line change commit, so you might figure out quick if it's correct or not :)

Regards,
Fred
